### PR TITLE
Fix type name float registered twice issue

### DIFF
--- a/onnx-docker/onnx-docker-cpu/Dockerfile
+++ b/onnx-docker/onnx-docker-cpu/Dockerfile
@@ -28,9 +28,7 @@ RUN mkdir -p /root/programs
 RUN git clone --recursive https://github.com/onnx/onnx.git /root/programs/onnx
 RUN git clone --recursive https://github.com/pytorch/pytorch.git /root/programs/pytorch
 RUN cd /root/programs/onnx; python setup.py develop
-RUN cd /root/programs/pytorch; pip install -r "caffe2/requirements.txt"; \
-    CMAKE_ARGS="-DCAFFE2_LINK_LOCAL_PROTOBUF=OFF -DBUILD_CUSTOM_PROTOBUF=OFF -DUSE_CUDA=OFF" python setup_caffe2.py develop
 RUN cd /root/programs/pytorch; pip install -r "requirements.txt"; \
-    NO_CUDA=1 python setup.py build develop
+    NO_CUDA=1 FULL_CAFFE2=1 python setup.py build develop
 
 WORKDIR /root/programs

--- a/onnx-docker/onnx-docker-gpu/Dockerfile
+++ b/onnx-docker/onnx-docker-gpu/Dockerfile
@@ -35,9 +35,7 @@ RUN mkdir -p /root/programs
 RUN git clone --recursive https://github.com/onnx/onnx.git /root/programs/onnx
 RUN git clone --recursive https://github.com/pytorch/pytorch.git /root/programs/pytorch
 RUN cd /root/programs/onnx; python setup.py develop
-RUN cd /root/programs/pytorch; pip install -r "caffe2/requirements.txt"; \
-    CMAKE_ARGS="-DCAFFE2_LINK_LOCAL_PROTOBUF=OFF -DBUILD_CUSTOM_PROTOBUF=OFF" python setup_caffe2.py develop
 RUN cd /root/programs/pytorch; pip install -r "requirements.txt"; \
-    NO_CUDA=0 python setup.py build develop
+    NO_CUDA=0 FULL_CAFFE2=1 python setup.py build develop
 
 WORKDIR /root/programs


### PR DESCRIPTION
Change from separate builds for caffe2 and pytorch to
a single build to fix the 'type name float registered
twice' issue. This runtime issue is discussed in
https://github.com/pytorch/pytorch/issues/10460